### PR TITLE
Fix map, filter etc. break maxBy, minBy?

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ var skipReargMap = {
 /** The source object to transform and assign to `_`. */
 var source = {
   'callback': function(func, thisArg, argCount) {
-    argCount = argCount > 2 ? (argCount - 2) : 1;
     return ary(callback(func, thisArg), argCount);
   }
 };


### PR DESCRIPTION
Adds array/object and index/key arguments to map, filter etc. iteratee functions. Side effect: maxBy and minBy also have array/object and index/key arguments.